### PR TITLE
Fix incorrect go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bohehe/go-session-redis/v3
+module github.com/go-session/redis/v3
 
 go 1.17
 


### PR DESCRIPTION
I'm so sorry for this mistake @LyricTian ,
I renamed back the go module name now.
https://github.com/go-session/redis/pull/8/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1